### PR TITLE
Implemented a generic registration screen, pending final adjustments

### DIFF
--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Register/RegisterCoordinator.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Register/RegisterCoordinator.swift
@@ -25,6 +25,10 @@ final class RegisterCoordinator: RegisterCoordinatoring, ObservableObject {
         }
     }
     
+    func startRegister(){
+        self.nav.push(.SignUpView)
+    }
+    
     deinit{
         print("🚫🚫 RegisterCoordinator DESTRUIDO  🚫🚫")
     }

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Register/RegisterView.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Register/RegisterView.swift
@@ -88,7 +88,7 @@ extension RegisterView {
             height: 58,
             font: FontMaker.makeFont(.poppinsSemiBold, fontSize)
         ) {
-            // ação e-mail
+            RegisterCoordinator(nav: nav).startRegister() 
         }
         .padding(.horizontal, defaultPadding)
         .padding(.bottom, 5)

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpCoordinator.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpCoordinator.swift
@@ -1,0 +1,31 @@
+//
+//  SignUpCoordinator.swift
+//  pokedexSwiftUI
+//
+//  Created by Vinicius Cabral on 27/09/25.
+//
+
+import SwiftUI
+import Combine
+
+protocol SignUpCoordinatoring{
+    func back()
+    func finishedSignUp(user: SignUpModel)
+}
+
+final class SignUpCoordinator: SignUpCoordinatoring, ObservableObject {
+    private let nav: AppNavigator
+    
+    init(nav: AppNavigator) { self.nav = nav }
+    
+    func back() { withAnimation { nav.pop() } }
+    
+    func finishedSignUp(user: SignUpModel) {
+        // Ex.: empurra próxima rota, ou troca root
+        print("✅✅✅ FEZ O CADASTRO ✅✅✅")
+        withAnimation { nav.popToRoot() }
+    }
+    deinit{
+        print("🚫🚫 RegisterCoordinator DESTRUIDO  🚫🚫")
+    }
+}

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpModel.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpModel.swift
@@ -5,7 +5,7 @@
 //  Created by Vinicius Cabral on 27/09/25.
 //
 
-struct SignUpModel {
+struct SignUpModel: Equatable {
     var name: String
     var email: String
     var password: String

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpViewModel.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpViewModel.swift
@@ -5,14 +5,84 @@
 //  Created by Vinicius Cabral on 27/09/25.
 //
 
+import SwiftUI
 import Combine
+import Foundation
 
-class SignUpViewModel: ObservableObject{
-    @Published var user: SignUpModel
-    @Published var focusTextView: Bool
+enum SignUpStep: Int, CaseIterable {
+    case email, password, name
     
-    init(user: SignUpModel) {
-        self.user = user
-        self.focusTextView = false
+    var titleTop: String {
+        switch self {
+        case .email:    return "Vamos começar!"
+        case .password: return "Agora..."
+        case .name:     return "Pra finalizar"
+        }
+    }
+    
+    var titleMain: String {
+        switch self {
+        case .email:    return "Qual é o seu e-mail?"
+        case .password: return "Crie uma senha"
+        case .name:     return "Qual é o seu nome?"
+        }
+    }
+    
+    var helperText: String {
+        switch self {
+        case .email:    return "Use um endereço de e-mail válido."
+        case .password: return "Sua senha deve ter pelo menos 8 caracteres."
+        case .name:     return "Esse será seu nome de usuário no aplicativo."
+        }
+    }
+    
+    var placeholder: String {
+        switch self {
+        case .email:    return "E-mail"
+        case .password: return "Senha"
+        case .name:     return "Nome"
+        }
+    }
+    
+    var buttonTitle: String { self == .name ? "Criar conta" : "Continuar" }
+}
+
+// MARK: - ViewModel
+final class SignUpViewModel: ObservableObject {
+    @Published var user: SignUpModel = SignUpModel(name: "", email: "", password: "")
+    @Published var step: SignUpStep = .email
+    @Published var showPassword: Bool = false
+    @Published var isFocused: Bool = false
+    @Published var hasEditedCurrentField = false
+    
+    // Validações por step
+    var isContinueEnabled: Bool {
+        switch step {
+        case .email:
+            return isValidEmail(user.email)
+        case .password:
+            return user.password.count >= 8
+        case .name:
+            return user.name.trimmingCharacters(in: .whitespacesAndNewlines).count >= 2
+        }
+    }
+    
+    func nextStep() {
+        guard let next = SignUpStep(rawValue: step.rawValue + 1) else { return }
+        withAnimation(.easeInOut) { step = next }
+    }
+    
+    func previousStep() {
+        guard let prev = SignUpStep(rawValue: step.rawValue - 1) else { return }
+        withAnimation(.easeInOut) { step = prev }
+    }
+    
+    func resetPasswordVisibilityIfNeeded() {
+        if step != .password { showPassword = false }
+    }
+    
+    private func isValidEmail(_ email: String) -> Bool {
+        let regex = #"(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$"#
+        return email.range(of: regex, options: [.regularExpression]) != nil
     }
 }

--- a/pokedexSwiftUI/pokedexSwiftUI/Router/AppRouter.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Router/AppRouter.swift
@@ -13,6 +13,7 @@ enum AppRoute: Hashable, Identifiable {
     case loginOrRegister
     case register
     case login
+    case SignUpView
     // case home
     // case pokemonDetail(id: Int)
 
@@ -35,6 +36,8 @@ struct AppRouter {
             RegisterView(viewModel: RegisterViewModel(), isLogin: false)
         case .login:
             RegisterView(viewModel: RegisterViewModel(), isLogin: true)
+        case .SignUpView:
+            SignUpView(viewModel: SignUpViewModel())
         }
     }
 }


### PR DESCRIPTION
## Task Description
<!-- Provide a clear and concise description of the task or change. -->

This PR implements the sign-up flow within a single `SignUpView` driven by `SignUpStep` (email → password → name), eliminating multiple screens and simplifying navigation. `SignUpViewModel` centralizes state and logic—tracking `user`, `step`, `showPassword`, `isFocused`, email validation via a case-insensitive regex, `isContinueEnabled`, and `nextStep/previousStep`. The UI updates titles/placeholders/help text per step, uses `TextField`/`SecureField` with a password visibility toggle, styles the input border based on focus, and enables the Continue/Create Account button only when valid, with smooth transitions. Navigation is integrated via `SignUpCoordinator` (toolbar back moves one step back or pops at the first; on completion it triggers `finishedSignUp`). The router was updated to include the `SignUp` route, and a `#Preview` was added injecting `AppNavigator` and `SignUpViewModel`.

## Evidence
<!-- Indicate if there is supporting evidence (Yes/No). 
     If Yes, briefly describe or link it. -->

- [x] Yes  
- [ ] No

![Adobe Express - Simulator Screen Recording - iPhone 16 Pro - 2025-09-27 at 23 57 01](https://github.com/user-attachments/assets/6d173dcf-2cd8-42ce-a31a-3d014c1a2d25)
