### PR TITLE
Refactor SignUp Flow with DTO and Layered Separation

### DIFF
--- a/pokedexSwiftUI/pokedexSwiftUI/ContentView.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/ContentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        Text("ola")
+        Text(LocalizedStringKey("common.hello"))
     }
 }
 

--- a/pokedexSwiftUI/pokedexSwiftUI/Data/Auth/DTO/SignUpRequest.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Data/Auth/DTO/SignUpRequest.swift
@@ -1,0 +1,13 @@
+//
+//  SignUpRequest.swift
+//  pokedexSwiftUI
+//
+//  Created by Vinicius Cabral on 03/10/25.
+//
+
+// Transporte (o que vai no corpo da requisição)
+struct SignUpRequest: Encodable {
+    let email: String
+    let password: String
+    let name: String
+}

--- a/pokedexSwiftUI/pokedexSwiftUI/Data/Auth/Services/SignUpService.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Data/Auth/Services/SignUpService.swift
@@ -1,0 +1,50 @@
+//
+//  SignUpService.swift
+//  pokedexSwiftUI
+//
+//  Created by Vinicius Cabral on 03/10/25.
+//
+
+import Foundation
+
+protocol SignUpServicing {
+    func register(_ request: SignUpRequest) async throws -> User
+}
+
+enum SignUpError: Error {
+    case invalidStatus(Int)
+    case decoding
+    case transport(Error)
+}
+
+final class SignUpService: SignUpServicing {
+    private let session: URLSession
+    private let baseURL: URL
+
+    init(session: URLSession = .shared,
+         baseURL: URL = URL(string: "https://api.seu-backend.com")!) {
+        self.session = session
+        self.baseURL = baseURL
+    }
+
+    func register(_ request: SignUpRequest) async throws -> User {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent("/auth/signup"))
+        urlRequest.httpMethod = "POST"
+        urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = try JSONEncoder().encode(request)
+
+        do {
+            let (data, response) = try await session.data(for: urlRequest)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+                throw SignUpError.invalidStatus((response as? HTTPURLResponse)?.statusCode ?? -1)
+            }
+            do {
+                return try JSONDecoder().decode(User.self, from: data)
+            } catch {
+                throw SignUpError.decoding
+            }
+        } catch {
+            throw SignUpError.transport(error)
+        }
+    }
+}

--- a/pokedexSwiftUI/pokedexSwiftUI/Domain/Entities/User.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Domain/Entities/User.swift
@@ -1,0 +1,13 @@
+//
+//  User.swift
+//  pokedexSwiftUI
+//
+//  Created by Vinicius Cabral on 03/10/25.
+//
+
+// Domínio (o app usa depois do cadastro)
+struct User: SignedInUser, Decodable, Equatable {
+    let id: String
+    let email: String
+    let name: String
+}

--- a/pokedexSwiftUI/pokedexSwiftUI/Domain/Protocols/SignUpCoordinatoring.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Domain/Protocols/SignUpCoordinatoring.swift
@@ -1,0 +1,11 @@
+//
+//  SignUpCoordinatoring.swift
+//  pokedexSwiftUI
+//
+//  Created by Vinicius Cabral on 03/10/25.
+//
+
+protocol SignUpCoordinatoring {
+    func back()
+    func finishedSignUp(user: SignUpModel)
+}

--- a/pokedexSwiftUI/pokedexSwiftUI/Domain/Protocols/SignedInUser.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Domain/Protocols/SignedInUser.swift
@@ -1,0 +1,12 @@
+//
+//  SignedInUser.swift
+//  pokedexSwiftUI
+//
+//  Created by Vinicius Cabral on 03/10/25.
+//
+
+protocol SignedInUser {
+    var id: String { get }
+    var email: String { get }
+    var name: String { get }
+}

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/LoginOrRegister/LoginOrRegisterView.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/LoginOrRegister/LoginOrRegisterView.swift
@@ -24,7 +24,7 @@ struct LoginOrRegisterView: View {
             Spacer().frame(height: defaultPadding)
             registerAccount
         }
-        .navToolbar(leadingTitle: "Voltar") {
+        .navToolbar(leadingTitle: String(localized: "common.back")) {
             LoginOrRegisterCoordinator(nav: nav).back()
         }
     }
@@ -38,7 +38,7 @@ struct LoginOrRegisterView: View {
                 .clipShape(.capsule)
                 .foregroundStyle(ColorsNames.darkBlue)
                 .overlay {
-                    Text("Criar conta")
+                    Text(LocalizedStringKey("auth.createAccount"))
                         .foregroundStyle(.white)
                         .font(FontMaker.makeFont(.poppinsSemiBold, fontSize))
                 }
@@ -51,7 +51,7 @@ struct LoginOrRegisterView: View {
         Button(action: {
             LoginOrRegisterCoordinator(nav: nav).register()
         }, label: {
-            Text("Ja tenho uma conta")
+            Text(LocalizedStringKey("auth.alreadyHaveAccount"))
                 .foregroundStyle(ColorsNames.darkBlue)
                 .font(FontMaker.makeFont(.poppinsSemiBold, fontSize))
         })

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/LoginOrRegister/LoginOrRegisterViewModel.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/LoginOrRegister/LoginOrRegisterViewModel.swift
@@ -11,7 +11,7 @@ import Combine
 class LoginOrRegisterViewModel: ObservableObject {
     @Published var loginOrRegisterInformations: InfoTextKeys =
     InfoTextKeys(
-        titleKey: "Está pronto para essa aventura?",
-        descriptionKey: "Basta criar uma conta e começar a explorar o mundo dos Pokémon hoje!"
+        titleKey: "auth.welcome.title",
+        descriptionKey: "auth.welcome.description"
     )
 }

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Onboarding/OnboardingView.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Onboarding/OnboardingView.swift
@@ -89,7 +89,7 @@ extension OnboardingView{
                 .clipShape(.capsule)
                 .foregroundStyle(ColorsNames.darkBlue)
                 .overlay {
-                    Text("Continuar")
+                    Text(LocalizedStringKey("common.continue"))
                         .foregroundStyle(.white)
                         .font(FontMaker.makeFont(.poppinsSemiBold, 18))
                 }

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Onboarding/OnboardingViewModel.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Onboarding/OnboardingViewModel.swift
@@ -11,7 +11,7 @@ import Combine
 class OnboardingViewModel: ObservableObject {
     @Published var currentStep: Int = 0
     @Published var onboardingSteps: [InfoTextKeys] = [
-        InfoTextKeys(titleKey: "Todos os Pokémons em um só Lugar", descriptionKey: "Acesse uma vasta lista de Pokémon de todas as gerações já feitas pela Nintendo"),
-        InfoTextKeys(titleKey: "Mantenha sua\nPokédex atualizada", descriptionKey: "Cadastre-se e mantenha seu perfil, pokémon favoritos, configurações e muito mais, salvos no aplicativo, mesmo sem conexão com a internet.")
+        InfoTextKeys(titleKey: "onboarding.step1.title", descriptionKey: "onboarding.step1.description"),
+        InfoTextKeys(titleKey: "onboarding.step2.title", descriptionKey: "onboarding.step2.description")
     ]
 }

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Register/RegisterCoordinator.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Register/RegisterCoordinator.swift
@@ -26,7 +26,7 @@ final class RegisterCoordinator: RegisterCoordinatoring, ObservableObject {
     }
     
     func startRegister(){
-        self.nav.push(.SignUpView)
+        self.nav.push(.signUp)
     }
     
     deinit{

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Register/RegisterView.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Register/RegisterView.swift
@@ -29,7 +29,7 @@ struct RegisterView: View {
             createAccountWithGoogle
             createAccountWithEmailAndPassword
         }
-        .navToolbar(centerTitle: isLogin ? "Cadastro" : "Login"){
+        .navToolbar(centerTitle: isLogin ? String(localized: "auth.register.titleBar") : String(localized: "auth.login.titleBar")){
             RegisterCoordinator(nav: nav).back()
         }
     }
@@ -48,7 +48,7 @@ struct RegisterView: View {
 extension RegisterView {
     private var createAccountWithApple: some View {
         CapsuleButton(
-            title: "Continuar com a Apple",
+            title: String(localized: "auth.continueWithApple"),
             icon: .system("apple.logo"),
             style: .outline(stroke: Color.black.opacity(0.3),
                             background: .white,
@@ -65,7 +65,7 @@ extension RegisterView {
     
     private var createAccountWithGoogle: some View {
         CapsuleButton(
-            title: "Continuar com a Google",
+            title: String(localized: "auth.continueWithGoogle"),
             icon: .image(Image("VectorGoogle")),
             style: .outline(stroke: Color.black.opacity(0.3),
                             background: .white,
@@ -74,7 +74,7 @@ extension RegisterView {
             font: FontMaker.makeFont(.poppinsSemiBold, fontSize),
             iconSize: 22
         ) {
-            print(isLogin ? "login" : "cadastro")
+            print(isLogin ? "login" : "register")
         }
         .padding(.horizontal, defaultPadding)
         .padding(.bottom, 5)
@@ -82,7 +82,7 @@ extension RegisterView {
     
     private var createAccountWithEmailAndPassword: some View {
         CapsuleButton(
-            title: "Continuar com um e-mail",
+            title: String(localized: "auth.continueWithEmail"),
             icon: nil,
             style: .filled(background: ColorsNames.darkBlue, foreground: .white),
             height: 58,

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Register/RegisterViewModel.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/Register/RegisterViewModel.swift
@@ -11,11 +11,11 @@ import Combine
 class RegisterViewModel: ObservableObject {
     @Published var loginOrRegisterInformations: [InfoTextKeys] = [
     InfoTextKeys(
-        titleKey: "Falta pouco para\nexplorar esse mundo!",
-        descriptionKey: "Como deseja se conectar?"),
+        titleKey: "auth.register.title",
+        descriptionKey: "auth.connect.how"),
     InfoTextKeys(
-        titleKey: "Que bom te ver aqui novamente!",
-        descriptionKey: "Como deseja se conectar?")
+        titleKey: "auth.login.title",
+        descriptionKey: "auth.connect.how")
     ]
     
     func teste(){

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpCoordinator.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpCoordinator.swift
@@ -8,11 +8,6 @@
 import SwiftUI
 import Combine
 
-protocol SignUpCoordinatoring{
-    func back()
-    func finishedSignUp(user: SignUpModel)
-}
-
 final class SignUpCoordinator: SignUpCoordinatoring, ObservableObject {
     private let nav: AppNavigator
     
@@ -20,7 +15,7 @@ final class SignUpCoordinator: SignUpCoordinatoring, ObservableObject {
     
     func back() { withAnimation { nav.pop() } }
     
-    func finishedSignUp(user: SignUpModel) {
+    func finishedSignUp(user: some SignedInUser) {
         // Ex.: empurra próxima rota, ou troca root
         print("✅✅✅ FEZ O CADASTRO ✅✅✅")
         withAnimation { nav.popToRoot() }

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpModel.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpModel.swift
@@ -5,7 +5,8 @@
 //  Created by Vinicius Cabral on 27/09/25.
 //
 
-struct SignUpModel: Equatable {
+struct SignUpModel: SignedInUser, Equatable {
+    var id: String
     var name: String
     var email: String
     var password: String

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpView.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpView.swift
@@ -10,13 +10,22 @@ import SwiftUI
 struct SignUpView: View {
     @ObservedObject var viewModel: SignUpViewModel
     @EnvironmentObject var nav: AppNavigator
-    @FocusState private var fieldFocused: Bool
-    
+
+    private enum Field: Hashable { case email, password, name }
+    @FocusState private var focused: Field?
+
+    private var isCurrentFocused: Bool {
+        switch viewModel.step {
+        case .email:    return focused == .email
+        case .password: return focused == .password
+        case .name:     return focused == .name
+        }
+    }
+
     var body: some View {
         VStack(alignment: .center, spacing: 25) {
             Spacer().frame(height: 30)
-            
-            // Títulos
+
             VStack(alignment: .center, spacing: 6) {
                 Text(viewModel.step.titleTop)
                     .font(FontMaker.makeFont(.poppinsRegular, 26))
@@ -25,57 +34,78 @@ struct SignUpView: View {
             }
             .padding(.horizontal, 16)
             .transition(.opacity.combined(with: .move(edge: .top)))
-            
-            // Campo
+
             Group {
                 switch viewModel.step {
                 case .email:
-                    TextField(viewModel.step.placeholder, text: $viewModel.user.email) { editChange in
-                        viewModel.isFocused = true
-                    }
-                    .keyboardType(.emailAddress)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    
+                    TextField(viewModel.step.placeholder, text: $viewModel.user.email)
+                        .keyboardType(.emailAddress)
+                        .textInputAutocapitalization(.never)
+                        .textContentType(.emailAddress)
+                        .autocorrectionDisabled(true)
+                        .focused($focused, equals: .email)
+                        .submitLabel(.next)
+                        .onSubmit { handlePrimary() }
+
                 case .password:
-                    HStack {
-                        if viewModel.showPassword {
-                            TextField(viewModel.step.placeholder, text: $viewModel.user.password)
-                        } else {
-                            SecureField(viewModel.step.placeholder, text: $viewModel.user.password)
-                        }
+                    ZStack(alignment: .trailing) {
+                        TextField(viewModel.step.placeholder, text: $viewModel.user.password)
+                            .opacity(viewModel.showPassword ? 1 : 0)
+                            .focused($focused, equals: .password)
+                            .submitLabel(.next)
+                            .onSubmit { handlePrimary() }
+                            .textContentType(.newPassword)
+                            .autocorrectionDisabled(true)
+
+
+                        SecureField(viewModel.step.placeholder, text: $viewModel.user.password)
+                            .opacity(viewModel.showPassword ? 0 : 1)
+                            .focused($focused, equals: .password)
+                            .submitLabel(.next)
+                            .onSubmit { handlePrimary() }
+                            .textContentType(.newPassword)
+                            .autocorrectionDisabled(true)
+
                         Button {
+                            let wasFocused = (focused == .password)
                             viewModel.showPassword.toggle()
+                            if wasFocused {
+                                DispatchQueue.main.async { focused = .password }
+                            }
                         } label: {
-                            Image(systemName: viewModel.showPassword ? "eye.slash" : "eye")
+                            Image(systemName: viewModel.showPassword ? "eye" : "eye.slash")
                                 .foregroundStyle(ColorsNames.darkBlue)
                         }
+                        .padding(.trailing, 8)
                     }
-                    
+
                 case .name:
-                    TextField(viewModel.step.placeholder, text: $viewModel.user.name) { editChange in
-                        viewModel.isFocused = true
-                    }
-                    .textInputAutocapitalization(.words)
+                    TextField(viewModel.step.placeholder, text: $viewModel.user.name)
+                        .textInputAutocapitalization(.words)
+                        .focused($focused, equals: .name)
+                        .submitLabel(.done)
+                        .onSubmit { handlePrimary() }
+                        .textContentType(.name)
+                        .autocorrectionDisabled(true)
+                        .textInputAutocapitalization(.never)
                 }
             }
             .padding(14)
             .background(
                 RoundedRectangle(cornerRadius: 8)
-                    .stroke(viewModel.isFocused ? ColorsNames.darkBlue : Color.gray.opacity(0.4), lineWidth: 2)
+                    .stroke(isCurrentFocused ? ColorsNames.darkBlue : Color.gray.opacity(0.4), lineWidth: 2)
             )
             .padding(.horizontal, 16)
+            .id(viewModel.step)
             .transition(.move(edge: .trailing).combined(with: .opacity))
-            
+
+
             Text(viewModel.step.helperText)
                 .font(.footnote)
                 .foregroundColor(.gray)
                 .padding(.horizontal, 16)
                 .transition(.opacity)
-            
             Spacer()
-            
-            // Botão
             Button(action: handlePrimary) {
                 Text(viewModel.step.buttonTitle)
                     .frame(maxWidth: .infinity, minHeight: 56)
@@ -88,11 +118,9 @@ struct SignUpView: View {
             .padding(.horizontal, 16)
             .padding(.bottom, 8)
         }
-        .navToolbar(centerTitle: "Criar conta"){
-            SignUpCoordinator(nav: nav).back()
-        }
+        .navToolbar(centerTitle: "Criar conta") { handleBack() }
     }
-    
+
     private func handleBack() {
         if viewModel.step == .email {
             SignUpCoordinator(nav: nav).back()
@@ -103,7 +131,6 @@ struct SignUpView: View {
     
     private func handlePrimary() {
         guard viewModel.isContinueEnabled else { return }
-        viewModel.isFocused = false
         if viewModel.step == .name {
             // dispara o cadastro real (service) e, no sucesso:
             SignUpCoordinator(nav: nav).finishedSignUp(user: viewModel.user)
@@ -112,7 +139,6 @@ struct SignUpView: View {
         }
     }
 }
-
 
 #Preview {
     let nav = AppNavigator()

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpView.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpView.swift
@@ -10,10 +10,9 @@ import SwiftUI
 struct SignUpView: View {
     @ObservedObject var viewModel: SignUpViewModel
     @EnvironmentObject var nav: AppNavigator
-
-    private enum Field: Hashable { case email, password, name }
     @FocusState private var focused: Field?
-
+    private enum Field: Hashable { case email, password, name }
+    
     private var isCurrentFocused: Bool {
         switch viewModel.step {
         case .email:    return focused == .email
@@ -21,11 +20,11 @@ struct SignUpView: View {
         case .name:     return focused == .name
         }
     }
-
+    
     var body: some View {
         VStack(alignment: .center, spacing: 25) {
             Spacer().frame(height: 30)
-
+            
             VStack(alignment: .center, spacing: 6) {
                 Text(LocalizedStringKey(viewModel.step.titleTop))
                     .font(FontMaker.makeFont(.poppinsRegular, 26))
@@ -34,11 +33,11 @@ struct SignUpView: View {
             }
             .padding(.horizontal, 16)
             .transition(.opacity.combined(with: .move(edge: .top)))
-
+            
             Group {
                 switch viewModel.step {
                 case .email:
-                    TextField(LocalizedStringKey(viewModel.step.placeholder), text: $viewModel.user.email)
+                    TextField(LocalizedStringKey(viewModel.step.placeholder), text: $viewModel.email)
                         .keyboardType(.emailAddress)
                         .textInputAutocapitalization(.never)
                         .textContentType(.emailAddress)
@@ -46,26 +45,25 @@ struct SignUpView: View {
                         .focused($focused, equals: .email)
                         .submitLabel(.next)
                         .onSubmit { handlePrimary() }
-
+                    
                 case .password:
                     ZStack(alignment: .trailing) {
-                        TextField(LocalizedStringKey(viewModel.step.placeholder), text: $viewModel.user.password)
+                        TextField(LocalizedStringKey(viewModel.step.placeholder), text: $viewModel.password)
                             .opacity(viewModel.showPassword ? 1 : 0)
                             .focused($focused, equals: .password)
                             .submitLabel(.next)
                             .onSubmit { handlePrimary() }
                             .textContentType(.newPassword)
                             .autocorrectionDisabled(true)
-
-
-                        SecureField(LocalizedStringKey(viewModel.step.placeholder), text: $viewModel.user.password)
+                        
+                        SecureField(LocalizedStringKey(viewModel.step.placeholder), text: $viewModel.password)
                             .opacity(viewModel.showPassword ? 0 : 1)
                             .focused($focused, equals: .password)
                             .submitLabel(.next)
                             .onSubmit { handlePrimary() }
                             .textContentType(.newPassword)
                             .autocorrectionDisabled(true)
-
+                        
                         Button {
                             let wasFocused = (focused == .password)
                             viewModel.showPassword.toggle()
@@ -78,16 +76,15 @@ struct SignUpView: View {
                         }
                         .padding(.trailing, 8)
                     }
-
+                    
                 case .name:
-                    TextField(LocalizedStringKey(viewModel.step.placeholder), text: $viewModel.user.name)
+                    TextField(LocalizedStringKey(viewModel.step.placeholder), text: $viewModel.name)
+                        .textContentType(.name)
                         .textInputAutocapitalization(.words)
+                        .autocorrectionDisabled(true)
                         .focused($focused, equals: .name)
                         .submitLabel(.done)
                         .onSubmit { handlePrimary() }
-                        .textContentType(.name)
-                        .autocorrectionDisabled(true)
-                        .textInputAutocapitalization(.never)
                 }
             }
             .padding(14)
@@ -98,28 +95,42 @@ struct SignUpView: View {
             .padding(.horizontal, 16)
             .id(viewModel.step)
             .transition(.move(edge: .trailing).combined(with: .opacity))
-
+            
             Text(LocalizedStringKey(viewModel.step.helperText))
                 .font(.footnote)
                 .foregroundColor(.gray)
                 .padding(.horizontal, 16)
                 .transition(.opacity)
+            
             Spacer()
+            
             Button(action: handlePrimary) {
-                Text(LocalizedStringKey(viewModel.step.buttonTitle))
-                    .frame(maxWidth: .infinity, minHeight: 56)
-                    .font(.system(size: 18, weight: .semibold))
+                ZStack {
+                    Text(LocalizedStringKey(viewModel.step.buttonTitle))
+                        .frame(maxWidth: .infinity, minHeight: 56)
+                        .font(.system(size: 18, weight: .semibold))
+                    if viewModel.isLoading {
+                        ProgressView().progressViewStyle(.circular)
+                    }
+                }
             }
-            .disabled(!viewModel.isContinueEnabled)
+            .disabled(!viewModel.isContinueEnabled || viewModel.isLoading)
             .background(viewModel.isContinueEnabled ? ColorsNames.darkBlue : Color.gray.opacity(0.25))
             .foregroundStyle(Color.white)
             .clipShape(Capsule())
             .padding(.horizontal, 16)
             .padding(.bottom, 8)
         }
-        .navToolbar(centerTitle: "Criar conta") { handleBack() }
     }
-
+    
+    private func focusInitial() {
+        switch viewModel.step {
+        case .email:    focused = .email
+        case .password: focused = .password
+        case .name:     focused = .name
+        }
+    }
+    
     private func handleBack() {
         if viewModel.step == .email {
             SignUpCoordinator(nav: nav).back()
@@ -130,13 +141,27 @@ struct SignUpView: View {
     
     private func handlePrimary() {
         guard viewModel.isContinueEnabled else { return }
+        
         if viewModel.step == .name {
-            // dispara o cadastro real (service) e, no sucesso:
-            SignUpCoordinator(nav: nav).finishedSignUp(user: viewModel.user)
+            //            Task {
+            //                if let user = await viewModel.submit() {
+            // adapte aqui
+            let user = viewModel.submitMockUser()
+            SignUpCoordinator(nav: nav).finishedSignUp(user: user)
+            //                }
+            //            }
         } else {
             viewModel.nextStep()
         }
     }
+}
+
+// MARK: - Preview
+#Preview {
+    let nav = AppNavigator()
+    let vm = SignUpViewModel(service: SignUpService())
+    SignUpView(viewModel: vm)
+        .environmentObject(nav)
 }
 
 #Preview {

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpView.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpView.swift
@@ -27,9 +27,9 @@ struct SignUpView: View {
             Spacer().frame(height: 30)
 
             VStack(alignment: .center, spacing: 6) {
-                Text(viewModel.step.titleTop)
+                Text(LocalizedStringKey(viewModel.step.titleTop))
                     .font(FontMaker.makeFont(.poppinsRegular, 26))
-                Text(viewModel.step.titleMain)
+                Text(LocalizedStringKey(viewModel.step.titleMain))
                     .font(FontMaker.makeFont(.poppinsSemiBold, 26))
             }
             .padding(.horizontal, 16)
@@ -38,7 +38,7 @@ struct SignUpView: View {
             Group {
                 switch viewModel.step {
                 case .email:
-                    TextField(viewModel.step.placeholder, text: $viewModel.user.email)
+                    TextField(LocalizedStringKey(viewModel.step.placeholder), text: $viewModel.user.email)
                         .keyboardType(.emailAddress)
                         .textInputAutocapitalization(.never)
                         .textContentType(.emailAddress)
@@ -49,7 +49,7 @@ struct SignUpView: View {
 
                 case .password:
                     ZStack(alignment: .trailing) {
-                        TextField(viewModel.step.placeholder, text: $viewModel.user.password)
+                        TextField(LocalizedStringKey(viewModel.step.placeholder), text: $viewModel.user.password)
                             .opacity(viewModel.showPassword ? 1 : 0)
                             .focused($focused, equals: .password)
                             .submitLabel(.next)
@@ -58,7 +58,7 @@ struct SignUpView: View {
                             .autocorrectionDisabled(true)
 
 
-                        SecureField(viewModel.step.placeholder, text: $viewModel.user.password)
+                        SecureField(LocalizedStringKey(viewModel.step.placeholder), text: $viewModel.user.password)
                             .opacity(viewModel.showPassword ? 0 : 1)
                             .focused($focused, equals: .password)
                             .submitLabel(.next)
@@ -80,7 +80,7 @@ struct SignUpView: View {
                     }
 
                 case .name:
-                    TextField(viewModel.step.placeholder, text: $viewModel.user.name)
+                    TextField(LocalizedStringKey(viewModel.step.placeholder), text: $viewModel.user.name)
                         .textInputAutocapitalization(.words)
                         .focused($focused, equals: .name)
                         .submitLabel(.done)
@@ -99,15 +99,14 @@ struct SignUpView: View {
             .id(viewModel.step)
             .transition(.move(edge: .trailing).combined(with: .opacity))
 
-
-            Text(viewModel.step.helperText)
+            Text(LocalizedStringKey(viewModel.step.helperText))
                 .font(.footnote)
                 .foregroundColor(.gray)
                 .padding(.horizontal, 16)
                 .transition(.opacity)
             Spacer()
             Button(action: handlePrimary) {
-                Text(viewModel.step.buttonTitle)
+                Text(LocalizedStringKey(viewModel.step.buttonTitle))
                     .frame(maxWidth: .infinity, minHeight: 56)
                     .font(.system(size: 18, weight: .semibold))
             }

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpViewModel.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpViewModel.swift
@@ -14,37 +14,37 @@ enum SignUpStep: Int, CaseIterable {
     
     var titleTop: String {
         switch self {
-        case .email:    return "Vamos começar!"
-        case .password: return "Agora..."
-        case .name:     return "Pra finalizar"
+        case .email:    return "signup.titleTop.start"
+        case .password: return "signup.titleTop.now"
+        case .name:     return "signup.titleTop.finish"
         }
     }
     
     var titleMain: String {
         switch self {
-        case .email:    return "Qual é o seu e-mail?"
-        case .password: return "Crie uma senha"
-        case .name:     return "Qual é o seu nome?"
+        case .email:    return "signup.titleMain.email"
+        case .password: return "signup.titleMain.password"
+        case .name:     return "signup.titleMain.name"
         }
     }
     
     var helperText: String {
         switch self {
-        case .email:    return "Use um endereço de e-mail válido."
-        case .password: return "Sua senha deve ter pelo menos 8 caracteres."
-        case .name:     return "Esse será seu nome de usuário no aplicativo."
+        case .email:    return "signup.helper.email"
+        case .password: return "signup.helper.password"
+        case .name:     return "signup.helper.name"
         }
     }
     
     var placeholder: String {
         switch self {
-        case .email:    return "E-mail"
-        case .password: return "Senha"
-        case .name:     return "Nome"
+        case .email:    return "signup.placeholder.email"
+        case .password: return "signup.placeholder.password"
+        case .name:     return "signup.placeholder.name"
         }
     }
     
-    var buttonTitle: String { self == .name ? "Criar conta" : "Continuar" }
+    var buttonTitle: String { self == .name ? "auth.createAccount" : "common.continue" }
 }
 
 // MARK: - ViewModel

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpViewModel.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpViewModel.swift
@@ -50,34 +50,83 @@ enum SignUpStep: Int, CaseIterable {
 // MARK: - ViewModel
 @MainActor
 final class SignUpViewModel: ObservableObject {
-    @Published var user: SignUpModel = SignUpModel(name: "", email: "", password: "")
+    @Published var email: String = ""
+    @Published var password: String = ""
+    @Published var name: String = ""
     @Published var step: SignUpStep = .email
     @Published var showPassword: Bool = false
-    @EnvironmentObject var nav: AppNavigator
-    
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+    private let service: SignUpServicing
+
+    init(service: SignUpServicing = SignUpService()) {
+        self.service = service
+    }
+
     var isContinueEnabled: Bool {
         switch step {
         case .email:
-            return isValidEmail(user.email)
+            return isValidEmail(email)
         case .password:
-            return user.password.count >= 8
+            return password.count >= 8
         case .name:
-            return user.name.trimmingCharacters(in: .whitespacesAndNewlines).count >= 2
+            return name.trimmingCharacters(in: .whitespacesAndNewlines).count >= 2
         }
     }
-    
+
+    func makeRequest() -> SignUpRequest {
+        .init(email: email, password: password, name: name)
+    }
+
     func nextStep() {
         guard let next = SignUpStep(rawValue: step.rawValue + 1) else { return }
         withAnimation(.easeInOut) { step = next }
     }
-    
+
     func previousStep() {
         guard let prev = SignUpStep(rawValue: step.rawValue - 1) else { return }
         withAnimation(.easeInOut) { step = prev }
     }
-    
+
+    func submit() async -> User? {
+        guard isContinueEnabled else { return nil }
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let dto = makeRequest()
+            let user = try await service.register(dto)
+            return user
+        } catch {
+            errorMessage = mapError(error)
+            return nil
+        }
+    }
+
+    // MARK: - Helpers
     private func isValidEmail(_ email: String) -> Bool {
         let regex = #"(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$"#
         return email.range(of: regex, options: [.regularExpression]) != nil
+    }
+
+    private func mapError(_ error: Error) -> String {
+        switch error {
+        case SignUpError.invalidStatus(let code):
+            return "Erro ao criar a conta (status \(code))."
+        case SignUpError.decoding:
+            return "Não consegui interpretar a resposta do servidor."
+        case SignUpError.transport(let underlying):
+            return "Falha de rede: \(underlying.localizedDescription)"
+        default:
+            return "Não foi possível criar a conta. Tente novamente."
+        }
+    }
+}
+
+// MARK: - Metodo fake
+extension SignUpViewModel{
+    func submitMockUser() -> User {
+        let user = User(id: "1234", email: "1@1.com", name: "Zé Maria")
+        return user
     }
 }

--- a/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpViewModel.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Presentation/AppFlow/SignUpFlow/SignUpViewModel.swift
@@ -48,14 +48,13 @@ enum SignUpStep: Int, CaseIterable {
 }
 
 // MARK: - ViewModel
+@MainActor
 final class SignUpViewModel: ObservableObject {
     @Published var user: SignUpModel = SignUpModel(name: "", email: "", password: "")
     @Published var step: SignUpStep = .email
     @Published var showPassword: Bool = false
-    @Published var isFocused: Bool = false
-    @Published var hasEditedCurrentField = false
+    @EnvironmentObject var nav: AppNavigator
     
-    // Validações por step
     var isContinueEnabled: Bool {
         switch step {
         case .email:
@@ -75,10 +74,6 @@ final class SignUpViewModel: ObservableObject {
     func previousStep() {
         guard let prev = SignUpStep(rawValue: step.rawValue - 1) else { return }
         withAnimation(.easeInOut) { step = prev }
-    }
-    
-    func resetPasswordVisibilityIfNeeded() {
-        if step != .password { showPassword = false }
     }
     
     private func isValidEmail(_ email: String) -> Bool {

--- a/pokedexSwiftUI/pokedexSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/pokedexSwiftUI/pokedexSwiftUI/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,34 @@
+"common.continue" = "Continue";
+"common.back" = "Back";
+"common.hello" = "Hello";
+
+"auth.welcome.title" = "Ready for this adventure?";
+"auth.welcome.description" = "Create an account and start exploring the world of Pokémon today!";
+"auth.createAccount" = "Create account";
+"auth.alreadyHaveAccount" = "I already have an account";
+"auth.continueWithApple" = "Continue with Apple";
+"auth.continueWithGoogle" = "Continue with Google";
+"auth.continueWithEmail" = "Continue with email";
+"auth.connect.how" = "How would you like to connect?";
+"auth.register.title" = "You're almost there to\nexplore this world!";
+"auth.login.title" = "Great to see you again!";
+"auth.register.titleBar" = "Sign up";
+"auth.login.titleBar" = "Login";
+
+"onboarding.step1.title" = "All Pokémon in one place";
+"onboarding.step1.description" = "Access a vast list of Pokémon from all generations released by Nintendo";
+"onboarding.step2.title" = "Keep your\nPokédex up to date";
+"onboarding.step2.description" = "Sign up and keep your profile, favorite Pokémon, settings and much more saved in the app, even offline.";
+
+"signup.titleTop.start" = "Let's get started!";
+"signup.titleTop.now" = "Now...";
+"signup.titleTop.finish" = "To finish";
+"signup.titleMain.email" = "What's your email?";
+"signup.titleMain.password" = "Create a password";
+"signup.titleMain.name" = "What's your name?";
+"signup.helper.email" = "Use a valid email address.";
+"signup.helper.password" = "Your password must be at least 8 characters.";
+"signup.helper.name" = "This will be your username in the app.";
+"signup.placeholder.email" = "Email";
+"signup.placeholder.password" = "Password";
+"signup.placeholder.name" = "Name";

--- a/pokedexSwiftUI/pokedexSwiftUI/Resources/pt-BR.lproj/Localizable.strings
+++ b/pokedexSwiftUI/pokedexSwiftUI/Resources/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,34 @@
+"common.continue" = "Continuar";
+"common.back" = "Voltar";
+"common.hello" = "Olá";
+
+"auth.welcome.title" = "Está pronto para essa aventura?";
+"auth.welcome.description" = "Basta criar uma conta e começar a explorar o mundo dos Pokémon hoje!";
+"auth.createAccount" = "Criar conta";
+"auth.alreadyHaveAccount" = "Já tenho uma conta";
+"auth.continueWithApple" = "Continuar com a Apple";
+"auth.continueWithGoogle" = "Continuar com o Google";
+"auth.continueWithEmail" = "Continuar com um e-mail";
+"auth.connect.how" = "Como deseja se conectar?";
+"auth.register.title" = "Falta pouco para\nexplorar esse mundo!";
+"auth.login.title" = "Que bom te ver aqui novamente!";
+"auth.register.titleBar" = "Cadastro";
+"auth.login.titleBar" = "Login";
+
+"onboarding.step1.title" = "Todos os Pokémons em um só Lugar";
+"onboarding.step1.description" = "Acesse uma vasta lista de Pokémon de todas as gerações já feitas pela Nintendo";
+"onboarding.step2.title" = "Mantenha sua\nPokédex atualizada";
+"onboarding.step2.description" = "Cadastre-se e mantenha seu perfil, pokémon favoritos, configurações e muito mais, salvos no aplicativo, mesmo sem conexão com a internet.";
+
+"signup.titleTop.start" = "Vamos começar!";
+"signup.titleTop.now" = "Agora...";
+"signup.titleTop.finish" = "Pra finalizar";
+"signup.titleMain.email" = "Qual é o seu e-mail?";
+"signup.titleMain.password" = "Crie uma senha";
+"signup.titleMain.name" = "Qual é o seu nome?";
+"signup.helper.email" = "Use um endereço de e-mail válido.";
+"signup.helper.password" = "Sua senha deve ter pelo menos 8 caracteres.";
+"signup.helper.name" = "Esse será seu nome de usuário no aplicativo.";
+"signup.placeholder.email" = "E-mail";
+"signup.placeholder.password" = "Senha";
+"signup.placeholder.name" = "Nome";

--- a/pokedexSwiftUI/pokedexSwiftUI/Router/AppRouter.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Router/AppRouter.swift
@@ -13,7 +13,7 @@ enum AppRoute: Hashable, Identifiable {
     case loginOrRegister
     case register
     case login
-    case SignUpView
+    case signUp
     // case home
     // case pokemonDetail(id: Int)
 
@@ -36,7 +36,7 @@ struct AppRouter {
             RegisterView(viewModel: RegisterViewModel(), isLogin: false)
         case .login:
             RegisterView(viewModel: RegisterViewModel(), isLogin: true)
-        case .SignUpView:
+        case .signUp:
             SignUpView(viewModel: SignUpViewModel())
         }
     }

--- a/pokedexSwiftUI/pokedexSwiftUI/Shared/DesignSystem/ViewComponents/TitleDescriptionView.swift
+++ b/pokedexSwiftUI/pokedexSwiftUI/Shared/DesignSystem/ViewComponents/TitleDescriptionView.swift
@@ -13,12 +13,12 @@ struct TitleDescriptionView: View {
     
     var body: some View {
         VStack(spacing: 16) {
-            Text(title)
+            Text(LocalizedStringKey(title))
                 .font(Font.custom("Poppins-Medium", size: 26))
                 .multilineTextAlignment(.center)
                 .foregroundStyle(Color("AppPrimary"))
 
-            Text(description)
+            Text(LocalizedStringKey(description))
                 .font(Font.custom("Poppins-Regular", size: 14))
                 .multilineTextAlignment(.center)
                 .foregroundStyle(Color("AppSecondary"))


### PR DESCRIPTION
## Task Description
<!-- Provide a clear and concise description of the task or change. -->
This PR refactors the user registration (SignUp) flow by introducing a DTO (SignUpRequest) to represent the network payload and by improving the separation of responsibilities between Presentation, Domain, and Data layers.

## Key changes:
•	Created SignUpRequest (DTO) in Data/DTO, isolating the network transport layer.
•	Introduced SignUpServicing in Domain to abstract the ViewModel’s dependency on the service.
•	Implemented SignUpService in Data/Services, responsible for performing HTTP calls.
•	SignUpViewModel now builds the DTO and delegates the registration process to the service, returning a User (domain entity).
•	Updated SignUpCoordinator to accept objects conforming to the SignedInUser protocol, reducing coupling to concrete types.
•	Reorganized folders and files under AppFlow/SignUpFlow, ensuring consistency in the feature-first architecture.

## Motivation:
•	Scalability: separating DTOs (transport), entities (domain), and UI state makes it easier to extend the feature in the future, such as supporting multiple authentication flows (SignUp, Login, OAuth).
•	Testability: with SignUpServicing defined as a protocol, it becomes simple to inject mocks into the ViewModel and test registration flows without relying on the network.
•	Cohesion and clarity: each layer now has a well-defined responsibility, reducing duplication and improving code readability.
•	Flexibility: using the SignedInUser protocol allows the Coordinator to work with different user representations without structural changes.

## Evidence
<!-- Indicate if there is supporting evidence (Yes/No). 
     If Yes, briefly describe or link it. -->

- [x] Yes  
- [ ] No

<img width="452" height="930" alt="image" src="https://github.com/user-attachments/assets/f29312a9-2148-411f-8133-ca7af1bb9931" />
